### PR TITLE
hotfix: Github profiles urls of Contributors

### DIFF
--- a/i18n/pt-BR/components/Contributors.yml
+++ b/i18n/pt-BR/components/Contributors.yml
@@ -49,5 +49,5 @@ instructions:
   title: "Como Contribuir"
   paragraphs:
     - "É simples. Encontrou um bug ou deseja um novo recurso?"
-    - 'Crie uma issue <a href="https://github.com/nullstack/nullstack/issues" target="_blank" rel="noopener" class="ci1">Crie uma issue </a> ou <a href="https://github.com/nullstack/nullstack/pulls" target="_blank" rel="noopener" class="ci1"> envie uma pull request </a> com testes'
+    - '<a href="https://github.com/nullstack/nullstack/issues" target="_blank" rel="noopener" class="ci1">Crie uma issue </a> ou <a href="https://github.com/nullstack/nullstack/pulls" target="_blank" rel="noopener" class="ci1"> envie uma pull request </a> com testes.'
 githubCacheWarning: "* A lista pode demorar um pouco para ser atualizada devido ao cache da API do GitHub"

--- a/src/Contributors.njs
+++ b/src/Contributors.njs
@@ -62,7 +62,7 @@ class Contributors extends Translatable {
         <img class="xl" src={`https://github.com/${github}.png`} alt={name} width="90" height="90" style="height: 90px" />
         <div class="md+x10 md+p3l sm-m3t">
           <h3>
-            <a href={github} target="_blank" rel="noopener" class="ci1">{name}</a>
+            <a href={`https://github.com/${github}`} target="_blank" rel="noopener" class="ci1">{name}</a>
           </h3>
           <h4 class="m1y"> {role} </h4>
           <p> {description} </p> 
@@ -91,7 +91,7 @@ class Contributors extends Translatable {
   renderContributor({login, avatar_url, html_url}) {
     return (
       <div class="xx sm-x6 bcm2 p2 m2t">
-        <a link={html_url} title={login} target="_blank" rel="noopener" class="ci1">
+        <a href={html_url} title={login} target="_blank" rel="noopener" class="ci1">
           <img class="xl" src={avatar_url} alt={login} width="90" height="90" style="height: 90px" />
         </a>
       </div>


### PR DESCRIPTION
Teu review no código limpou bastante coisa e agora também tá aparecendo os Contribuidores dinamicamente na página.

Sintaxe como essa é a mão na roda que eu estava procurando: `<Topic {...instructions} />`
E olha que já havia usado no React e não lembrava :sweat_smile: 

PS: Agora que parei pra ver que todo método de componente trabalha com objeto como argumento. Interessante.
Qual a origem disso?