### PR TITLE
Adding night-mode and storing preference

### DIFF
--- a/i18n/en-US/components/Header.yml
+++ b/i18n/en-US/components/Header.yml
@@ -16,3 +16,5 @@ links:
 action:
   title: "Get Started"
   href: "/getting-started"
+nightMode: "Night Mode"
+dayMode: "Day Mode"

--- a/i18n/pt-BR/components/Header.yml
+++ b/i18n/pt-BR/components/Header.yml
@@ -16,3 +16,5 @@ links:
 action:
   title: "Começar"
   href: "/pt-br/comecando"
+nightMode: "Modo Noite"
+dayMode: "Modo Dia"

--- a/src/Application.njs
+++ b/src/Application.njs
@@ -53,10 +53,10 @@ class Application extends Nullstack {
     )
   }
 
-  render({router}) {
+  render({router, isDark}) {
     const locale = router.url.startsWith('/pt-br') ? 'pt-BR' : 'en-US';
     return (
-      <main>
+      <main class={isDark ? `dark` : ''}>
         <Header locale={locale} />
 
         <Home route="/" locale="en-US" />

--- a/src/Application.scss
+++ b/src/Application.scss
@@ -64,6 +64,36 @@ section a img {
   }
 }
 
+.cursor-pointer {
+  cursor: pointer !important;
+}
+
+body * {
+  transition: all 50ms;
+}
+
+@mixin darkMode {
+  background-color: var(--heavy-color);
+  color: var(--soft-color);
+}
+
+.dark {
+  min-height: 100vh;
+  @include darkMode();
+
+  & article h2 a,
+  & article h3 a,
+  & .loader-cog,
+  & .loader-cog svg {
+    @include darkMode();
+  }
+
+  & .bgm2,
+  & .menu-links {
+    color: var(--heavy-color);
+  }
+}
+
 /*! purgecss start ignore */
 
 pre {

--- a/src/Components.njs
+++ b/src/Components.njs
@@ -19,7 +19,7 @@ class Components extends Translatable {
       <div class="x12 m6y bcm2 p4x p4t p1b">
         <h2 class="x12 sm-fs6 md+fs8 m3b"> {title} </h2>
         {tagline &&
-          <p class="bgs2 p2 m3y" title={tagline.title}> {tagline.text} </p>
+          <p class="p2 m3y" title={tagline.title}> {tagline.text} </p>
         }
         <nav class="x12"> 
           {projects.map(project => <Project {...project} />)} 

--- a/src/Header.njs
+++ b/src/Header.njs
@@ -17,8 +17,17 @@ class Header extends Translatable {
       > {title} </a>
     )
   }
-  
-  render() {
+
+  hydrate(context) {
+    context.isDark = !!(window.localStorage.getItem('isDark') === "true");
+  }
+
+  setDark(context) {
+    context.isDark = !context.isDark;
+    window.localStorage.setItem('isDark', context.isDark);
+  }
+
+  render({isDark}) {
     if(!this.i18n) return false;
     return (
       <header class="x12 pftl bgm1 bs2">
@@ -31,8 +40,14 @@ class Header extends Translatable {
               <element tag={this.expanded ? Ex : Bars} height={20} class="cm3" />
             </span>
           </div>
-          <nav class={`yy sm-p4 ${!this.expanded && 'sm-off'}`}>
+          <nav class={`menu-links yy sm-p4 ${!this.expanded && 'sm-off'}`}>
             {this.i18n.links.map((link) => <Link {...link} />)}
+            <p
+              class="cursor-pointer sm-x12 sm-bcm2b p2 ci1:h"
+              onclick={this.setDark}
+            >
+              {this.i18n[`${isDark ? 'day' : 'night'}Mode`]}
+            </p>
           </nav>
           <div class={`sm-x12 sm-p4x ${!this.expanded && 'sm-off'}`}>
             <a href={this.i18n.action.href} onclick={{expanded: false}} class="xx sm-x12 bci1 bgi1 bgm1:h cm1 ci1:h p4x p2y">

--- a/src/Home.njs
+++ b/src/Home.njs
@@ -14,8 +14,8 @@ class Home extends Translatable {
     return (
       <section class="x xx sm-p2x p20y">
         <h1 class="x12 sm-fs8 md+fs12"> {this.i18n.hero.heading} </h1>
-        <div class="xx x8 m12b" style="background-image: linear-gradient(0deg, #fff 49%, #e2e8f0 50%, #fff 52%);"> 
-          <p class="bgm1 fs6 p2"> {this.i18n.hero.tagline} </p>
+        <div class="xx x8 m12b"> 
+          <p class="fs6 p2"> {this.i18n.hero.tagline} </p>
         </div>
         <div>
           {this.i18n.hero.descriptions.map((description, index, {length}) => 

--- a/src/Loader.njs
+++ b/src/Loader.njs
@@ -6,7 +6,7 @@ class Loader extends Nullstack {
   render({worker}) {
     if(!worker.fetching) return false;
     return (
-      <div class="z24 pftl xx yy x12 xvw y12 yvh bgm1 op18">
+      <div class="loader-cog z24 pftl xx yy x12 xvw y12 yvh bgm1 op18">
         <Cog animation="spin" speed="slow" height={40} class="cm3" />
       </div>
     )


### PR DESCRIPTION
Fui fundo na ideia e vi como o context é atualizado no pai de acordo com o filho o.o

Então ficou assim:
Parágrafo clicável no Header muda o modo no context e salva no `localStorage`.
Que mantém ao atualizar a página.
closes #42

PS: um bug detalhista encontrado é que estou pegando do `localStorage` no `hydrate` (onde o `window` é disponível) qual demora uns milissegundos após o render, carregando o day-mode antes do night :sweat_smile: