### PR TITLE
Fix typo

### DIFF
--- a/i18n/en-US/articles/service-worker.md
+++ b/i18n/en-US/articles/service-worker.md
@@ -208,7 +208,7 @@ class LoginPage extends Nullstack {
 
   async submit({worker}) {
     // ...
-    this.headers['Authorization'] = `Bearer ${token}`;
+    worker.headers['Authorization'] = `Bearer ${token}`;
     // ...
   }
 


### PR DESCRIPTION
The correct way to change a header is through the `worker` instance, and not on `this`.