### PR TITLE
Add apple-touch-icon metatag info

### DIFF
--- a/i18n/en-US/articles/context-project.md
+++ b/i18n/en-US/articles/context-project.md
@@ -40,6 +40,8 @@ Besides `domain`, `name` and `color` all other keys have sensible defaults gener
 
 If you do not declare the `icons` key, Nullstack will scan any icons with the name following the pattern "icon-[WIDTH]x[HEIGHT].png" in your **public** folder.
 
+The `head` meta tag `apple-touch-icon` will be set to your `icon-180x180.png` file.
+
 If the `sitemap` key is set to true your **robots.txt** file will point the sitemap to `https://${project.domain}/sitemap.xml`.
 
 The `cdn` key will prefix your asset bundles and will be available in the context so you can manually prefix other assets.

--- a/i18n/pt-BR/articles/contexto-project.md
+++ b/i18n/pt-BR/articles/contexto-project.md
@@ -40,6 +40,8 @@ Além de `domain`, `name` and `color` todas as outras chaves tem padrões sensí
 
 Se você não declarar a chave `icons`, Nullstack irá escanear quaisquer ícones com o nome seguindo o padrão "icon-[LARGURA]x[ALTURA].png" na sua pasta **public**.
 
+A meta tag `apple-touch-icon` de `head` irá ser igual ao seu arquivo `icon-180x180.png`.
+
 Se a chave `sitemap` estiver definida como `true` o seu arquivo **robots.txt** irá apontar o sitemap para `https://${project.domain}/sitemap.xml`.
 
 A chave `cdn` irá prefixar seu pacote de assets e ficará disponível no contexto para que você possa manualmente prefixar outros ativos.


### PR DESCRIPTION
Adds apple-touch-icon info in the context page

<img width="773" alt="image" src="https://user-images.githubusercontent.com/39849232/211933337-bd584132-f964-4746-9e75-e666a14418cc.png">

