### PR TITLE
Increase social media card image

### DIFF
--- a/src/Application.njs
+++ b/src/Application.njs
@@ -24,6 +24,7 @@ class Application extends Nullstack {
         <link rel="preload" href="/roboto-v20-latin-300.woff2" as="font" type="font/woff2" crossorigin />
         <link rel="preload" href="/roboto-v20-latin-500.woff2" as="font" type="font/woff2" crossorigin />
         <link rel="preload" href="/crete-round-v9-latin-regular.woff2" as="font" type="font/woff2" crossorigin />
+        <meta name="twitter:card" content="summary_large_image" />
       </head>
     )
   }


### PR DESCRIPTION
Just giving a try on what makes this:
<img src="https://github.com/nullstack/nullstack.github.io/assets/31557312/c89ddeeb-c37a-478b-80a6-b913e2d74160" height="150" />

More like this:
<img src="https://github.com/nullstack/nullstack.github.io/assets/31557312/5e48161e-0318-48ac-972e-166e4c4546d2" height="300" />

Just did [here](https://github.com/GuiDevloper/nullstack-new/blob/02c73269ba984ea25230ea69395a1a402432a886/src/Application.tsx#L30) on my [Nullstack New](https://github.com/GuiDevloper/nullstack-new) project and this is the result:
<img src="https://github.com/nullstack/nullstack.github.io/assets/31557312/fc9ec24d-06d4-4443-9860-d4f7c02dcbfc" height="300"/>
